### PR TITLE
ivar 1.3 with amplicon filter

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -23,6 +23,9 @@ params{
     // Scheme version
     schemeVersion = 'V2'
 
+    // For ivar's amplicon filter
+    primer_pairs_tsv = false
+
     // Run experimental medaka pipeline? Specify in the command using "--medaka"
     medaka = false
 
@@ -45,4 +48,9 @@ params{
     CLIMBHostname = false
 }
 
+executor {
+    name   = 'local'
+    cpus   = 20
+    memory = '16GB'
+}
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -47,3 +47,5 @@ params{
     // CLIMB hostname
     CLIMBHostname = false
 }
+
+

--- a/conf/base.config
+++ b/conf/base.config
@@ -47,10 +47,3 @@ params{
     // CLIMB hostname
     CLIMBHostname = false
 }
-
-executor {
-    name   = 'local'
-    cpus   = 20
-    memory = '16GB'
-}
-

--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -10,5 +10,5 @@ dependencies:
   - bwa=0.7.17=pl5.22.0_2
   - samtools=1.9
   - trim-galore=0.6.5
-  - ivar=1.2.2
+  - ivar=1.3
   - mafft=7.471

--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - biopython=1.74
   - pandas=0.23.0=py36_1
   - bwa=0.7.17=pl5.22.0_2
-  - samtools=1.9
+  - samtools=1.10
   - trim-galore=0.6.5
   - ivar=1.3
   - mafft=7.471

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -97,7 +97,7 @@ process trimPrimerSequences {
         """
         samtools view -F4 -o ${sampleName}.mapped.bam ${bam}
         samtools index ${sampleName}.mapped.bam
-        ${ivarCmd} -i ${sampleName}.mapped.bam -b ${bedfile} -m ${params.illuminaKeepLen} -q ${params.illuminaQualThreshold} -p ivar.out
+        ${ivarCmd} -i ${sampleName}.mapped.bam -b ${bedfile} -m ${params.illuminaKeepLen} -q ${params.illuminaQualThreshold} -f ${params.primer_pairs_tsv} -p ivar.out
         samtools sort -o ${sampleName}.mapped.primertrimmed.sorted.bam ivar.out.bam
         """
 }


### PR DESCRIPTION
Fixes #6 

- Update ivar to v1.3
- Pipeline now requires additional input, passed as `--primer_pairs_tsv`. This file contains the names of the outer primers for each amplicon, as a two-column .tsv file.