### PR TITLE
Add Dehosting

### DIFF
--- a/bin/filter_non_human_reads.py
+++ b/bin/filter_non_human_reads.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+import pysam
+import sys
+import argparse
+
+def filter_reads(contig_name, input_sam_fp, output_bam_fp):
+
+    # use streams if args are None
+    if input_sam_fp:
+        input_sam = pysam.AlignmentFile(input_sam_fp, 'r')
+    else:
+        input_sam = pysam.AlignmentFile('-', 'r')
+
+    if output_bam_fp:
+        output_bam = pysam.AlignmentFile(output_bam_fp, 'wb',
+                                         template=input_sam)
+    else:
+        output_bam = pysam.AlignmentFile('-', 'wb', template=input_sam)
+
+    # if read isn't mapped or mapped to viral reference contig name
+    viral_reads = 0
+    human_reads = 0
+    unmapped_reads = 0
+
+    # iterate over input from BWA
+    for read in input_sam:
+        # only look at primary alignments
+        if not read.is_supplementary and not read.is_secondary:
+            if read.reference_name == contig_name:
+                output_bam.write(read)
+                viral_reads += 1
+            elif read.is_unmapped:
+                output_bam.write(read)
+                unmapped_reads +=1
+            else:
+                human_reads += 1
+
+    total_reads = viral_reads + human_reads + unmapped_reads
+
+    print(f"viral read count = {viral_reads} "
+            f"({viral_reads/total_reads * 100:.2f}%)", file=sys.stderr)
+    print(f"human read count = {human_reads} "
+            f"({human_reads/total_reads * 100:.2f}%) ", file=sys.stderr)
+    print(f"unmapped read count = {unmapped_reads} "
+            f"({unmapped_reads/total_reads * 100:.2f}%)", file=sys.stderr)
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description="Get all reads that are "
+                                                  "unmapped and map to a "
+                                                  "specific reference "
+                                                  "contig")
+    parser.add_argument('-i', '--input', required=False, default=False,
+                        help="Input SAM formatted file (stdin used if "
+                              " not specified)")
+
+    parser.add_argument('-o', '--output', required=False, default=False,
+                        help="Output BAM formatted file (stdout used if not "
+                             "specified)")
+
+    parser.add_argument('-c', '--contig_name', required=False,
+                        default="MN908947.3",
+                        help="Contig name to retain e.g. viral")
+
+    args = parser.parse_args()
+
+    filter_reads(args.contig_name, args.input, args.output)

--- a/conf/base.config
+++ b/conf/base.config
@@ -7,9 +7,9 @@ params{
     basecalled_fastq = false
     fast5_pass = false
     sequencing_summary = false
-    ref = '/.mounts/labs/simpsonlab/projects/ncov/ref/artic-ncov2019/primer_schemes/nCoV-2019/V3/nCoV-2019.reference.fasta'
-    bed = '/.mounts/labs/gsiprojects/genomics/SARS-CoV-2/PHOCOV2/ncov2019ArticNf.manual.V3/nCoV-2019.bed'
-    human_ref = '/.mounts/labs/simpsonlab/data/references/GRCh38_no_alt_analysis_set.GCA_000001405.15.fna'
+    ref = false
+    bed = false
+    human_ref = false
     profile = false
 
     // Repo to download your primer scheme from

--- a/conf/base.config
+++ b/conf/base.config
@@ -9,8 +9,12 @@ params{
     sequencing_summary = false
     ref = false
     bed = false
-    human_ref = false
+
     profile = false
+    
+    // host filtering
+    composite_ref = false
+    viral_contig_name = false
 
     // Repo to download your primer scheme from
     schemeRepoURL = 'https://github.com/artic-network/artic-ncov2019.git'

--- a/conf/base.config
+++ b/conf/base.config
@@ -7,8 +7,9 @@ params{
     basecalled_fastq = false
     fast5_pass = false
     sequencing_summary = false
-    ref = false
-    bed = false
+    ref = '/.mounts/labs/simpsonlab/projects/ncov/ref/artic-ncov2019/primer_schemes/nCoV-2019/V3/nCoV-2019.reference.fasta'
+    bed = '/.mounts/labs/gsiprojects/genomics/SARS-CoV-2/PHOCOV2/ncov2019ArticNf.manual.V3/nCoV-2019.bed'
+    human_ref = '/.mounts/labs/simpsonlab/data/references/GRCh38_no_alt_analysis_set.GCA_000001405.15.fna'
     profile = false
 
     // Repo to download your primer scheme from
@@ -21,7 +22,7 @@ params{
     scheme =  'nCoV-2019'
 
     // Scheme version
-    schemeVersion = 'V2'
+    schemeVersion = 'V3'
 
     // Run experimental medaka pipeline? Specify in the command using "--medaka"
     medaka = false

--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - trim-galore=0.6.5
   - ivar=1.2.2
   - mafft=7.471
+  - pysam=0.15.2

--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -8,8 +8,8 @@ dependencies:
   - biopython=1.74
   - pandas=0.23.0=py36_1
   - bwa=0.7.17=pl5.22.0_2
-  - samtools=1.9
+  - samtools=1.10
   - trim-galore=0.6.5
   - ivar=1.2.2
   - mafft=7.471
-  - pysam=0.15.2
+  - pysam=0.16.0.1

--- a/main.nf
+++ b/main.nf
@@ -10,6 +10,7 @@ include printHelp from './modules/help.nf'
 include {articNcovNanopore} from './workflows/articNcovNanopore.nf' 
 include {ncovIllumina} from './workflows/illuminaNcov.nf'
 include {ncovIlluminaCram} from './workflows/illuminaNcov.nf'
+include {getSampleId; prepareFastqPair; performHostFilter} from './modules/utils'
 
 if (params.help){
     printHelp()
@@ -71,7 +72,10 @@ if ( ! params.prefix ) {
 
 // main workflow
 workflow {
+
    if ( params.illumina ) {
+       performHostFilter(prepareFastqPair.out)
+
        if (params.cram) {
            Channel.fromPath( "${params.directory}/**.cram" )
                   .map { file -> tuple(file.baseName, file) }

--- a/main.nf
+++ b/main.nf
@@ -10,7 +10,7 @@ include printHelp from './modules/help.nf'
 include {articNcovNanopore} from './workflows/articNcovNanopore.nf' 
 include {ncovIllumina} from './workflows/illuminaNcov.nf'
 include {ncovIlluminaCram} from './workflows/illuminaNcov.nf'
-include {getSampleId; prepareFastqPair; performHostFilter} from './modules/utils'
+include {performHostFilter} from './modules/utils'
 
 if (params.help){
     printHelp()

--- a/main.nf
+++ b/main.nf
@@ -10,7 +10,6 @@ include printHelp from './modules/help.nf'
 include {articNcovNanopore} from './workflows/articNcovNanopore.nf' 
 include {ncovIllumina} from './workflows/illuminaNcov.nf'
 include {ncovIlluminaCram} from './workflows/illuminaNcov.nf'
-include {performHostFilter} from './modules/utils'
 
 if (params.help){
     printHelp()
@@ -74,8 +73,6 @@ if ( ! params.prefix ) {
 workflow {
 
    if ( params.illumina ) {
-       performHostFilter(prepareFastqPair.out)
-
        if (params.cram) {
            Channel.fromPath( "${params.directory}/**.cram" )
                   .map { file -> tuple(file.baseName, file) }

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -6,8 +6,9 @@ process performHostFilter {
 
     script:
         """
-        bwa mem -t ${task.cpus} ${params.human_ref} ${forward} ${reverse} | samtools view -q 30 -U ${sampleId}.host_unaligned.bam -Sb > ${sampleId}.host_aligned.bam
-        samtools sort -n ${sampleId}.host_unaligned.bam | \
+        bwa mem -t ${task.cpus} ${params.composite_ref} ${forward} ${reverse} | \
+            filter_non_human_reads.py -c ${params.viral_contig_name} > ${sampleId}.viral_and_nonmapping_reads.bam
+        samtools sort -n ${sampleId}.viral_and_nonmapping_reads.bam | \
              samtools fastq -1 ${sampleId}_hostfiltered_R1.fastq.gz -2 ${sampleId}_hostfiltered_R2.fastq.gz -s ${sampleId}_singletons.fastq.gz -
         """
 }

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -1,0 +1,13 @@
+process performHostFilter {
+    input:
+        tuple(val(sampleId), path(forward), path(reverse))
+    output:
+        tuple sampleId, path("${sampleId}_hostfiltered_R1.fastq.gz"), path("${sampleId}_hostfiltered_R2.fastq.gz"), emit: fastqPairs
+
+    script:
+        """
+        bwa mem -t ${task.cpus} ${params.human_ref} ${forward} ${reverse} | samtools view -q 30 -U ${sampleId}.host_unaligned.bam -Sb > ${sampleId}.host_aligned.bam
+        samtools sort -n ${sampleId}.host_unaligned.bam | \
+             samtools fastq -1 ${sampleId}_hostfiltered_R1.fastq.gz -2 ${sampleId}_hostfiltered_R2.fastq.gz -s ${sampleId}_singletons.fastq.gz -
+        """
+}

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -1,4 +1,9 @@
 process performHostFilter {
+
+    tag { sampleId }
+
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${sampleId}_hostfiltered_*.fastq.gz", mode: 'copy'
+
     input:
         tuple(val(sampleId), path(forward), path(reverse))
     output:

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -12,6 +12,7 @@ include {trimPrimerSequences} from '../modules/illumina.nf'
 include {callVariants} from '../modules/illumina.nf'
 include {makeConsensus} from '../modules/illumina.nf' 
 include {cramToFastq} from '../modules/illumina.nf'
+include {performHostFilter} from '../modules/utils'
 include {alignConsensus} from '../modules/illumina.nf'
 include {trimUTR} from '../modules/illumina.nf'
 
@@ -139,9 +140,12 @@ workflow ncovIllumina {
       // Build or download fasta, index and bedfile as required
       prepareReferenceFiles()
       
+      // filter out any host reads
+      performHostFilter(ch_filePairs)
+
       // Actually do analysis
-      sequenceAnalysis(ch_filePairs, prepareReferenceFiles.out.bwaindex, prepareReferenceFiles.out.bedfile)
- 
+      sequenceAnalysis(performHostFilter.out, prepareReferenceFiles.out.bwaindex, prepareReferenceFiles.out.bedfile)
+
       // Upload files to CLIMB
       if ( params.upload ) {
         


### PR DESCRIPTION
Fixes #7 

Add dehosting step taken directly from [oicr-gsi/ncov2019-artic-nf](https://github.com/oicr-gsi/ncov2019-artic-nf).

This dehosting approach was initially developed in the context of the [CanCOGeN-V/covid-19-signal](https://github.com/CanCOGeN-V/covid-19-signal) pipeline

In order to perform this step, we will have to pass in an additional input file, the `--composite_ref`. Preparation of the composite reference file for dehosting is described in the [get_data_dependencies.sh](https://github.com/jaleezyy/covid-19-signal/blob/877fa06facf6a9a1db93ef6313d92a3e4353de39/scripts/get_data_dependencies.sh#L58-L66) script from the CanCOGeN-V/covid-19-signal pipeline.

An additional parameter `--viral_contig_name` is also required, which should be set to `MN908947.3` to match [the fasta defline in our nCoV-2019 reference sequence](https://github.com/BCCDC-PHL/artic-ncov2019/blob/d3c902e1ef96dd77b959cac9a293f13e44ff5d56/primer_schemes/nCoV-2019/V1200/nCoV-2019.reference.fasta#L1)