### PR TITLE
Prepare for v2.0 release

### DIFF
--- a/.github/scripts/prepare_composite_ref.sh
+++ b/.github/scripts/prepare_composite_ref.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 echo Prepare Composite Ref .. >> artifacts/test_artifact.log
 
 ref_storage_dir="/github/home/composite_ref"
+mkdir ${ref_storage_dir}
 
 # get the GRCh38 human genome
 # as per https://lh3.github.io/2017/11/13/which-human-reference-genome-to-use

--- a/.github/scripts/prepare_composite_ref.sh
+++ b/.github/scripts/prepare_composite_ref.sh
@@ -18,6 +18,3 @@ curl -s "https://raw.githubusercontent.com/BCCDC-PHL/artic-ncov2019/master/prime
 # create composite reference of human and virus for competitive bwt mapping 
 # based host removal
 cat ${ref_storage_dir}/GRC38_no_alt_analysis_set.fna ${ref_storage_dir}/nCoV-2019.reference.fasta > ${ref_storage_dir}/composite_human_viral_reference.fna
-bwa index ${ref_storage_dir}/composite_human_viral_reference.fna
-
-

--- a/.github/scripts/prepare_composite_ref.sh
+++ b/.github/scripts/prepare_composite_ref.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eo pipefail
 
+export PATH=/opt/conda/bin:$PATH
+
 echo Prepare Composite Ref .. >> artifacts/test_artifact.log
 
 ref_storage_dir="${GITHUB_WORKSPACE}/composite_ref"

--- a/.github/scripts/prepare_composite_ref.sh
+++ b/.github/scripts/prepare_composite_ref.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 echo Prepare Composite Ref .. >> artifacts/test_artifact.log
 
-ref_storage_dir="/github/home/composite_ref"
+ref_storage_dir="${GITHUB_WORKSPACE}/composite_ref"
 mkdir ${ref_storage_dir}
 
 # get the GRCh38 human genome

--- a/.github/scripts/prepare_composite_ref.sh
+++ b/.github/scripts/prepare_composite_ref.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eo pipefail
+
+echo Prepare Composite Ref .. >> artifacts/test_artifact.log
+
+ref_storage_dir="/github/home/composite_ref"
+
+# get the GRCh38 human genome
+# as per https://lh3.github.io/2017/11/13/which-human-reference-genome-to-use
+curl -s "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz" > ${ref_storage_dir}/GRC38_no_alt_analysis_set.fna.gz
+gunzip ${ref_storage_dir}/GRC38_no_alt_analysis_set.fna.gz
+
+curl -s "https://raw.githubusercontent.com/BCCDC-PHL/artic-ncov2019/master/primer_schemes/nCoV-2019/V1200/nCoV-2019.reference.fasta" > ${ref_storage_dir}/nCoV-2019.reference.fasta
+
+# create composite reference of human and virus for competitive bwt mapping 
+# based host removal
+cat ${ref_storage_dir}/GRC38_no_alt_analysis_set.fna ${ref_storage_dir}/nCoV-2019.reference.fasta > ${ref_storage_dir}/composite_human_viral_reference.fna
+bwa index ${ref_storage_dir}/composite_human_viral_reference.fna
+
+

--- a/.github/scripts/prepare_composite_ref_index.sh
+++ b/.github/scripts/prepare_composite_ref_index.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eo pipefail
+
+export PATH=/opt/conda/bin:$PATH
+
+echo Prepare Composite Ref .. >> artifacts/test_artifact.log
+
+ref_storage_dir="${GITHUB_WORKSPACE}/composite_ref"
+mkdir ${ref_storage_dir}
+
+# get the GRCh38 human genome
+# as per https://lh3.github.io/2017/11/13/which-human-reference-genome-to-use
+curl -s "ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz" > ${ref_storage_dir}/GRC38_no_alt_analysis_set.fna.gz
+gunzip ${ref_storage_dir}/GRC38_no_alt_analysis_set.fna.gz
+
+curl -s "https://raw.githubusercontent.com/BCCDC-PHL/artic-ncov2019/master/primer_schemes/nCoV-2019/V1200/nCoV-2019.reference.fasta" > ${ref_storage_dir}/nCoV-2019.reference.fasta
+
+# create composite reference of human and virus for competitive bwt mapping 
+# based host removal
+cat ${ref_storage_dir}/GRC38_no_alt_analysis_set.fna ${ref_storage_dir}/nCoV-2019.reference.fasta > ${ref_storage_dir}/composite_human_viral_reference.fna
+bwa index ${ref_storage_dir}/composite_human_viral_reference.fna
+
+

--- a/.github/scripts/test_PR_against_release.sh
+++ b/.github/scripts/test_PR_against_release.sh
@@ -2,12 +2,10 @@
 set -eo pipefail
 export PATH=/opt/conda/bin:$PATH
 
-# run current pull request code
-singularity --version
 # write test log as github Action artifact
 echo Nextflow run current PR in --illumina mode.. >> artifacts/test_artifact.log
-NXF_VER=20.03.0-edge nextflow run ./main.nf \
-       -profile singularity \
+NXF_VER=20.10.0 nextflow run ./main.nf \
+       -profile conda \
        --directory $PWD/.github/data/fastqs/ \
        --illumina \
        --prefix test
@@ -17,15 +15,15 @@ cp -r results results_singularity_profile
 cp -r work work_singularity_profile
 
 # run tests against previous previous_release to compare outputs 
-git clone https://github.com/connor-lab/ncov2019-artic-nf.git previous_release 
+git clone https://github.com/BCCDC-PHL/ncov2019-artic-nf.git previous_release 
 cd previous_release
-git checkout 5e00ba938d9e9f903a8da381a87eaff874e09802 
+git checkout tags/v1.0
 # the github runner only has 2 cpus available, so replace for that commit required:
 sed -i s'/cpus = 4/cpus = 2/'g conf/resources.config
-ln -s ../*.sif ./
+
 echo Nextflow run previous release in --illumina mode.. >> ../artifacts/test_artifact.log
-NXF_VER=20.03.0-edge nextflow run ./main.nf \
-       -profile singularity \
+NXF_VER=20.10.0 nextflow run ./main.nf \
+       -profile conda \
        --directory $PWD/../.github/data/fastqs/ \
        --illumina \
        --prefix test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,6 +18,10 @@ jobs:
        export PATH=/opt/conda/bin:$PATH
        conda install -c bioconda nextflow
        NXF_VER=20.10.0 nextflow -version
+    - name: install bwa via Conda
+      run: |
+       export PATH=/opt/conda/bin:$PATH
+       conda install -c bioconda bwa
     - name: Prepare composite reference sequence
       run: bash .github/scripts/prepare_composite_ref.sh
     - name: test PR outputs against previous release

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
        export PATH=/opt/conda/bin:$PATH
        conda install -c bioconda bwa
     - name: Prepare composite reference sequence
-      run: bash .github/scripts/prepare_composite_ref.sh
+      run: bash .github/scripts/prepare_composite_ref.sh 2> artifacts/test_artifact.log
     - name: test PR outputs against previous release
       run: bash .github/scripts/test_PR_against_release.sh
     - name: test --cache conda environment 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,6 +25,8 @@ jobs:
        export PATH=/opt/conda/bin:$PATH
        conda install -c bioconda nextflow
        NXF_VER=20.03.0-edge nextflow -version
+    - name: Prepare composite reference sequence
+      run: bash .github/scripts/prepare_composite_ref.sh
     - name: test PR outputs against previous release
       run: bash .github/scripts/test_PR_against_release.sh
     - name: test -profile sanger

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,34 +11,21 @@ jobs:
     - uses: actions/checkout@master
     - name: create artifacts dir to save test logs
       run: mkdir artifacts
-    - name: install Singularity
-      run: |
-       bash .github/scripts/install_singularity.sh
-    - name: Build pipeline Singularity containers
-      run: |
-       echo $(which singularity)
-       bash scripts/build_singularity_containers.sh
     - name: install Conda
       run: bash .github/scripts/install_conda.sh
     - name: install Nextflow via Conda
       run: |
        export PATH=/opt/conda/bin:$PATH
        conda install -c bioconda nextflow
-       NXF_VER=20.03.0-edge nextflow -version
+       NXF_VER=20.10.0 nextflow -version
     - name: Prepare composite reference sequence
       run: bash .github/scripts/prepare_composite_ref.sh
     - name: test PR outputs against previous release
       run: bash .github/scripts/test_PR_against_release.sh
-    - name: test -profile sanger
-      run: bash .github/scripts/test_sanger_profile.sh
     - name: test --cache conda environment 
       run: bash .github/scripts/test_conda_cache.sh
     - name: test --bed and --ref input options 
       run: bash .github/scripts/test_bed_ref_input.sh
-    - name: test --cram input together with --bed and --ref
-      run: bash .github/scripts/test_cram_input.sh
-    - name: test --outCram output together with --cram and --ref
-      run: bash .github/scripts/test_cram_output.sh
     - name: if failure, add latest NF log to artifacts
       run: mv .nextflow.log artifacts/failure.nextflow.log
       if: failure()

--- a/bin/filter_non_human_reads.py
+++ b/bin/filter_non_human_reads.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+import pysam
+import sys
+import argparse
+
+def filter_reads(contig_name, input_sam_fp, output_bam_fp):
+
+    # use streams if args are None
+    if input_sam_fp:
+        input_sam = pysam.AlignmentFile(input_sam_fp, 'r')
+    else:
+        input_sam = pysam.AlignmentFile('-', 'r')
+
+    if output_bam_fp:
+        output_bam = pysam.AlignmentFile(output_bam_fp, 'wb',
+                                         template=input_sam)
+    else:
+        output_bam = pysam.AlignmentFile('-', 'wb', template=input_sam)
+
+    # if read isn't mapped or mapped to viral reference contig name
+    viral_reads = 0
+    human_reads = 0
+    unmapped_reads = 0
+
+    # iterate over input from BWA
+    for read in input_sam:
+        # only look at primary alignments
+        if not read.is_supplementary and not read.is_secondary:
+            if read.reference_name == contig_name:
+                output_bam.write(read)
+                viral_reads += 1
+            elif read.is_unmapped:
+                output_bam.write(read)
+                unmapped_reads +=1
+            else:
+                human_reads += 1
+
+    total_reads = viral_reads + human_reads + unmapped_reads
+
+    print(f"viral read count = {viral_reads} "
+            f"({viral_reads/total_reads * 100:.2f}%)", file=sys.stderr)
+    print(f"human read count = {human_reads} "
+            f"({human_reads/total_reads * 100:.2f}%) ", file=sys.stderr)
+    print(f"unmapped read count = {unmapped_reads} "
+            f"({unmapped_reads/total_reads * 100:.2f}%)", file=sys.stderr)
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description="Get all reads that are "
+                                                  "unmapped and map to a "
+                                                  "specific reference "
+                                                  "contig")
+    parser.add_argument('-i', '--input', required=False, default=False,
+                        help="Input SAM formatted file (stdin used if "
+                              " not specified)")
+
+    parser.add_argument('-o', '--output', required=False, default=False,
+                        help="Output BAM formatted file (stdout used if not "
+                             "specified)")
+
+    parser.add_argument('-c', '--contig_name', required=False,
+                        default="MN908947.3",
+                        help="Contig name to retain e.g. viral")
+
+    args = parser.parse_args()
+
+    filter_reads(args.contig_name, args.input, args.output)

--- a/conf/base.config
+++ b/conf/base.config
@@ -7,9 +7,9 @@ params{
     basecalled_fastq = false
     fast5_pass = false
     sequencing_summary = false
-    ref = '/.mounts/labs/simpsonlab/projects/ncov/ref/artic-ncov2019/primer_schemes/nCoV-2019/V3/nCoV-2019.reference.fasta'
-    bed = '/.mounts/labs/gsiprojects/genomics/SARS-CoV-2/PHOCOV2/ncov2019ArticNf.manual.V3/nCoV-2019.bed'
-    human_ref = '/.mounts/labs/simpsonlab/data/references/GRCh38_no_alt_analysis_set.GCA_000001405.15.fna'
+    ref = false
+    bed = false
+    human_ref = false
     profile = false
 
     // Repo to download your primer scheme from

--- a/conf/base.config
+++ b/conf/base.config
@@ -9,8 +9,12 @@ params{
     sequencing_summary = false
     ref = false
     bed = false
-    human_ref = false
+
     profile = false
+    
+    // host filtering
+    composite_ref = false
+    viral_contig_name = false
 
     // Repo to download your primer scheme from
     schemeRepoURL = 'https://github.com/artic-network/artic-ncov2019.git'

--- a/conf/base.config
+++ b/conf/base.config
@@ -7,8 +7,9 @@ params{
     basecalled_fastq = false
     fast5_pass = false
     sequencing_summary = false
-    ref = false
-    bed = false
+    ref = '/.mounts/labs/simpsonlab/projects/ncov/ref/artic-ncov2019/primer_schemes/nCoV-2019/V3/nCoV-2019.reference.fasta'
+    bed = '/.mounts/labs/gsiprojects/genomics/SARS-CoV-2/PHOCOV2/ncov2019ArticNf.manual.V3/nCoV-2019.bed'
+    human_ref = '/.mounts/labs/simpsonlab/data/references/GRCh38_no_alt_analysis_set.GCA_000001405.15.fna'
     profile = false
 
     // Repo to download your primer scheme from
@@ -21,7 +22,7 @@ params{
     scheme =  'nCoV-2019'
 
     // Scheme version
-    schemeVersion = 'V2'
+    schemeVersion = 'V3'
 
     // Run experimental medaka pipeline? Specify in the command using "--medaka"
     medaka = false

--- a/conf/base.config
+++ b/conf/base.config
@@ -23,6 +23,9 @@ params{
     // Scheme version
     schemeVersion = 'V2'
 
+    // For ivar's amplicon filter
+    primer_pairs_tsv = false
+
     // Run experimental medaka pipeline? Specify in the command using "--medaka"
     medaka = false
 
@@ -45,4 +48,9 @@ params{
     CLIMBHostname = false
 }
 
+executor {
+    name   = 'local'
+    cpus   = 20
+    memory = '16GB'
+}
 

--- a/conf/base.config
+++ b/conf/base.config
@@ -47,3 +47,5 @@ params{
     // CLIMB hostname
     CLIMBHostname = false
 }
+
+

--- a/conf/base.config
+++ b/conf/base.config
@@ -47,10 +47,3 @@ params{
     // CLIMB hostname
     CLIMBHostname = false
 }
-
-executor {
-    name   = 'local'
-    cpus   = 20
-    memory = '16GB'
-}
-

--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - trim-galore=0.6.5
   - ivar=1.2.2
   - mafft=7.471
+  - pysam=0.15.2

--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -8,8 +8,8 @@ dependencies:
   - biopython=1.74
   - pandas=0.23.0=py36_1
   - bwa=0.7.17=pl5.22.0_2
-  - samtools=1.9
+  - samtools=1.10
   - trim-galore=0.6.5
   - ivar=1.2.2
   - mafft=7.471
-  - pysam=0.15.2
+  - pysam=0.16.0.1

--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   - samtools=1.9
   - trim-galore=0.6.5
   - ivar=1.2.2
+  - mafft=7.471

--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -10,5 +10,5 @@ dependencies:
   - bwa=0.7.17=pl5.22.0_2
   - samtools=1.9
   - trim-galore=0.6.5
-  - ivar=1.2.2
+  - ivar=1.3
   - mafft=7.471

--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - biopython=1.74
   - pandas=0.23.0=py36_1
   - bwa=0.7.17=pl5.22.0_2
-  - samtools=1.9
+  - samtools=1.10
   - trim-galore=0.6.5
   - ivar=1.3
   - mafft=7.471

--- a/main.nf
+++ b/main.nf
@@ -10,6 +10,7 @@ include printHelp from './modules/help.nf'
 include {articNcovNanopore} from './workflows/articNcovNanopore.nf' 
 include {ncovIllumina} from './workflows/illuminaNcov.nf'
 include {ncovIlluminaCram} from './workflows/illuminaNcov.nf'
+include {getSampleId; prepareFastqPair; performHostFilter} from './modules/utils'
 
 if (params.help){
     printHelp()
@@ -71,7 +72,10 @@ if ( ! params.prefix ) {
 
 // main workflow
 workflow {
+
    if ( params.illumina ) {
+       performHostFilter(prepareFastqPair.out)
+
        if (params.cram) {
            Channel.fromPath( "${params.directory}/**.cram" )
                   .map { file -> tuple(file.baseName, file) }

--- a/main.nf
+++ b/main.nf
@@ -10,7 +10,7 @@ include printHelp from './modules/help.nf'
 include {articNcovNanopore} from './workflows/articNcovNanopore.nf' 
 include {ncovIllumina} from './workflows/illuminaNcov.nf'
 include {ncovIlluminaCram} from './workflows/illuminaNcov.nf'
-include {getSampleId; prepareFastqPair; performHostFilter} from './modules/utils'
+include {performHostFilter} from './modules/utils'
 
 if (params.help){
     printHelp()

--- a/main.nf
+++ b/main.nf
@@ -10,7 +10,6 @@ include printHelp from './modules/help.nf'
 include {articNcovNanopore} from './workflows/articNcovNanopore.nf' 
 include {ncovIllumina} from './workflows/illuminaNcov.nf'
 include {ncovIlluminaCram} from './workflows/illuminaNcov.nf'
-include {performHostFilter} from './modules/utils'
 
 if (params.help){
     printHelp()
@@ -74,8 +73,6 @@ if ( ! params.prefix ) {
 workflow {
 
    if ( params.illumina ) {
-       performHostFilter(prepareFastqPair.out)
-
        if (params.cram) {
            Channel.fromPath( "${params.directory}/**.cram" )
                   .map { file -> tuple(file.baseName, file) }

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -163,3 +163,50 @@ process cramToFastq {
         """
 }
 
+process alignConsensus {
+
+    tag { sampleName }
+
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${sampleName}.primertrimmed.consensus.aln.fa", mode: 'copy'
+
+    input:
+        tuple(sampleName, path(consensus), path(reference))
+
+    output:
+        tuple(sampleName, path("${sampleName}.primertrimmed.consensus.aln.fa"))
+
+    script:
+        // Convert multi-line fasta to single line
+        awk_string = '/^>/ {printf("\\n%s\\n", $0); next; } { printf("%s", $0);}  END {printf("\\n");}'
+        """
+        mafft \
+          --preservecase \
+          --keeplength \
+          --add \
+          ${consensus} \
+          ${reference} \
+          > ${sampleName}.with_ref.multi_line.alignment.fa
+        awk '${awk_string}' ${sampleName}.with_ref.multi_line.alignment.fa > ${sampleName}.with_ref.single_line.alignment.fa
+        tail -n 2 ${sampleName}.with_ref.single_line.alignment.fa > ${sampleName}.primertrimmed.consensus.aln.fa
+        """
+}
+
+process trimUTR {
+
+    tag { sampleName }
+    executor 'local'
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${sampleName}.primertrimmed.consensus.aln.utr_trimmed.fa", mode: 'copy'
+
+    input:
+        tuple(sampleName, path(alignment))
+
+    output:
+        tuple(sampleName, path("${sampleName}.primertrimmed.consensus.aln.utr_trimmed.fa"))
+
+    script:
+        """
+        echo -e "\$(head -n 1 ${alignment} | cut -c 2-):256-29664" > non_utr.txt
+        samtools faidx ${alignment}
+        samtools faidx -r non_utr.txt ${alignment} > ${sampleName}.primertrimmed.consensus.aln.utr_trimmed.fa
+        """
+}

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -97,7 +97,7 @@ process trimPrimerSequences {
         """
         samtools view -F4 -o ${sampleName}.mapped.bam ${bam}
         samtools index ${sampleName}.mapped.bam
-        ${ivarCmd} -i ${sampleName}.mapped.bam -b ${bedfile} -m ${params.illuminaKeepLen} -q ${params.illuminaQualThreshold} -p ivar.out
+        ${ivarCmd} -i ${sampleName}.mapped.bam -b ${bedfile} -m ${params.illuminaKeepLen} -q ${params.illuminaQualThreshold} -f ${params.primer_pairs_tsv} -p ivar.out
         samtools sort -o ${sampleName}.mapped.primertrimmed.sorted.bam ivar.out.bam
         """
 }

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -6,8 +6,9 @@ process performHostFilter {
 
     script:
         """
-        bwa mem -t ${task.cpus} ${params.human_ref} ${forward} ${reverse} | samtools view -q 30 -U ${sampleId}.host_unaligned.bam -Sb > ${sampleId}.host_aligned.bam
-        samtools sort -n ${sampleId}.host_unaligned.bam | \
+        bwa mem -t ${task.cpus} ${params.composite_ref} ${forward} ${reverse} | \
+            filter_non_human_reads.py -c ${params.viral_contig_name} > ${sampleId}.viral_and_nonmapping_reads.bam
+        samtools sort -n ${sampleId}.viral_and_nonmapping_reads.bam | \
              samtools fastq -1 ${sampleId}_hostfiltered_R1.fastq.gz -2 ${sampleId}_hostfiltered_R2.fastq.gz -s ${sampleId}_singletons.fastq.gz -
         """
 }

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -1,0 +1,13 @@
+process performHostFilter {
+    input:
+        tuple(val(sampleId), path(forward), path(reverse))
+    output:
+        tuple sampleId, path("${sampleId}_hostfiltered_R1.fastq.gz"), path("${sampleId}_hostfiltered_R2.fastq.gz"), emit: fastqPairs
+
+    script:
+        """
+        bwa mem -t ${task.cpus} ${params.human_ref} ${forward} ${reverse} | samtools view -q 30 -U ${sampleId}.host_unaligned.bam -Sb > ${sampleId}.host_aligned.bam
+        samtools sort -n ${sampleId}.host_unaligned.bam | \
+             samtools fastq -1 ${sampleId}_hostfiltered_R1.fastq.gz -2 ${sampleId}_hostfiltered_R2.fastq.gz -s ${sampleId}_singletons.fastq.gz -
+        """
+}

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -1,4 +1,9 @@
 process performHostFilter {
+
+    tag { sampleId }
+
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${sampleId}_hostfiltered_*.fastq.gz", mode: 'copy'
+
     input:
         tuple(val(sampleId), path(forward), path(reverse))
     output:

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -12,6 +12,8 @@ include {trimPrimerSequences} from '../modules/illumina.nf'
 include {callVariants} from '../modules/illumina.nf'
 include {makeConsensus} from '../modules/illumina.nf' 
 include {cramToFastq} from '../modules/illumina.nf'
+include {alignConsensus} from '../modules/illumina.nf'
+include {trimUTR} from '../modules/illumina.nf'
 
 include {makeQCCSV} from '../modules/qc.nf'
 include {writeQCSummaryCSV} from '../modules/qc.nf'
@@ -96,6 +98,10 @@ workflow sequenceAnalysis {
       callVariants(trimPrimerSequences.out.ptrim.combine(ch_preparedRef.map{ it[0] }))     
 
       makeConsensus(trimPrimerSequences.out.ptrim)
+
+      alignConsensus(makeConsensus.out.combine(ch_preparedRef.map{ it[0] }))
+
+      trimUTR(alignConsensus.out)
 
       makeQCCSV(trimPrimerSequences.out.ptrim.join(makeConsensus.out, by: 0)
                                    .combine(ch_preparedRef.map{ it[0] }))

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -12,6 +12,7 @@ include {trimPrimerSequences} from '../modules/illumina.nf'
 include {callVariants} from '../modules/illumina.nf'
 include {makeConsensus} from '../modules/illumina.nf' 
 include {cramToFastq} from '../modules/illumina.nf'
+include {performHostFilter} from '../modules/utils'
 include {alignConsensus} from '../modules/illumina.nf'
 include {trimUTR} from '../modules/illumina.nf'
 
@@ -139,9 +140,12 @@ workflow ncovIllumina {
       // Build or download fasta, index and bedfile as required
       prepareReferenceFiles()
       
+      // filter out any host reads
+      performHostFilter(ch_filePairs)
+
       // Actually do analysis
-      sequenceAnalysis(ch_filePairs, prepareReferenceFiles.out.bwaindex, prepareReferenceFiles.out.bedfile)
- 
+      sequenceAnalysis(performHostFilter.out, prepareReferenceFiles.out.bwaindex, prepareReferenceFiles.out.bedfile)
+
       // Upload files to CLIMB
       if ( params.upload ) {
         


### PR DESCRIPTION
This update incorporates three main changes:

Fixes #2
* Add steps to align each consensus sequence against the reference, and trim 3' and 5' UTR sequences

Fixes #6 
* Update ivar version to 1.3, which includes improved primer trimming and an 'amplicon filtering' step to filter reads that are not enclosed by the outermost primers for an amplicon.

Fixes #7 
* Add a step at the beginning of the pipeline to perform host sequence removal (dehosting).