### PR TITLE
Downsample amplicons

### DIFF
--- a/bin/downsample_amplicons.py
+++ b/bin/downsample_amplicons.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python
+
+import argparse
+import csv
+import json
+import re
+import sys
+
+import pysam
+
+from collections import defaultdict
+
+
+def merge_primers(p1, p2):
+    try:
+        assert p1['direction'] == p2['direction']
+    except AssertionError as e:
+        err_message = "Error parsing bed file. primers " + p1['primer_id'] + " and " + p2['primer_id'] + " not in same direction, cannot be merged"
+        print(err_message, file=sys.stderr)
+        sys.exit(1)
+    if p1['direction'] == '+':
+        if p1['start'] < p2['start']:
+            merged_primer = p1
+        else:
+            merged_primer = p2
+    elif p1['direction'] == '-':
+        if p1['end'] > p2['end']:
+            merged_primer = p1
+        else:
+            merged_primer = p2
+
+    return merged_primer
+
+
+def read_bed_file(bed_file_path):
+    """
+          { "nCoV-2019_1_LEFT": {
+                                  "chrom": "MN908947.3",
+                                  "start": 30,
+                                  "end": 54,
+                                  "primer_id": "nCoV-2019_1_LEFT",
+                                  "pool_name": "1",
+                                  "direction": "+"
+                                 },
+            "nCoV-2019_1_RIGHT": {
+                                   "chrom": "MN908947.3",
+                                   "start": 1183,
+                                   "end": 1205,
+                                   "primer_id": "nCoV-2019_1_RIGHT",
+                                   "pool_name": "1",
+                                   "direction": "-"
+                                 },
+            ...
+          }
+    """
+    fieldnames = [
+        'chrom',
+        'start',
+        'end',
+        'primer_id',
+        'pool_name',
+        'direction'
+    ]
+    int_fields = [
+        'start',
+        'end',
+    ]
+    primers = {}
+    with open(bed_file_path, 'r') as f:
+        reader = csv.DictReader(f, fieldnames=fieldnames, dialect='excel-tab')
+        for row in reader:
+            for field in int_fields:
+                row[field] = int(row[field])
+            if re.search('_alt', row['primer_id']):
+                primer_id = re.match('(.+)_alt', row['primer_id']).group(1)
+            else:
+                primer_id = row['primer_id']
+            if all([not primer_id == primer_key for primer_key in primers.keys()]):
+                primers[primer_id] = row
+            else:
+                existing_primer = primers[primer_id]
+                merged_primer = merge_primers(existing_primer, row)
+                merged_primer['primer_id'] = primer_id
+                primers[primer_id] = merged_primer
+
+    return primers
+
+
+def midpoint(start, end):
+    """
+    Find the midpoint between two loci
+    returns: int
+    """
+    mid = round(start + ((end - start) / 2))
+    return mid
+
+
+def get_initial_amplicon_checkpoints(parsed_bed):
+    """
+    input: { "nCoV-2019_1_LEFT": {
+                                  "chrom": "MN908947.3",
+                                  "start": 30,
+                                  "end": 54,
+                                  "primer_id": "nCoV-2019_1_LEFT",
+                                  "pool_name": "1",
+                                  "direction": "+"
+                                 },
+            "nCoV-2019_1_RIGHT": {
+                                   "chrom": "MN908947.3",
+                                   "start": 1183,
+                                   "end": 1205,
+                                   "primer_id": "nCoV-2019_1_RIGHT",
+                                   "pool_name": "1",
+                                   "direction": "-"
+                                 },
+            ...
+          }
+    returns: {
+               "nCoV-2019_1": [64, 618, 1173],
+               "nCoV-2019_2": [1138, 1683, 2234],
+               ...
+             }
+    """
+    amplicon_checkpoints = {}
+    for primer_id, primer in parsed_bed.items():
+        amplicon_id = re.match("(.+)_LEFT", primer_id)
+        if amplicon_id:
+            amplicon_checkpoints[amplicon_id.group(1)] = {}
+
+    for amplicon_id in amplicon_checkpoints:
+        left_primer_id = amplicon_id + "_LEFT"
+        right_primer_id = amplicon_id + "_RIGHT"
+        left_primer = parsed_bed[left_primer_id]
+        right_primer = parsed_bed[right_primer_id]
+        # consider ends of amplicon to be inner ends of primers
+        amplicon_start = left_primer['end']
+        amplicon_end = right_primer['start']
+        amplicon_midpoint = midpoint(amplicon_start, amplicon_end)
+        # add a 10-base buffer inside the ends of the primers to define our first and last checkpoints
+        amplicon_checkpoints[amplicon_id] = [(amplicon_start + 10), amplicon_midpoint, (amplicon_end - 10)]
+    
+    return amplicon_checkpoints
+
+
+def subdivide_amplicon_checkpoints(amplicon_checkpoints):
+    """
+    input: [64, 618, 1173]
+    output: [64, 341, 618, 896, 1173]
+    """
+    new_amplicon_checkpoints = []
+    for idx in range(len(amplicon_checkpoints)):
+        try:
+            new_checkpoint = midpoint(amplicon_checkpoints[idx], amplicon_checkpoints[idx + 1])
+            new_amplicon_checkpoints.append(new_checkpoint)
+        except IndexError as e:
+            pass
+
+        all_checkpoints = amplicon_checkpoints + new_amplicon_checkpoints
+        all_checkpoints.sort()
+        
+    return all_checkpoints
+
+
+def read_pair_generator(bam, region_string=None):
+    """
+    from: https://www.biostars.org/p/306041/#332022
+    Generate read pairs in a BAM file or within a region string.
+    Reads are added to read_dict until a pair is found.
+    """
+    read_dict = defaultdict(lambda: [None, None])
+    for read in bam.fetch(region=region_string):
+        if not read.is_proper_pair or read.is_secondary or read.is_supplementary:
+            continue
+        qname = read.query_name
+        if qname not in read_dict:
+            if read.is_read1:
+                read_dict[qname][0] = read
+            else:
+                read_dict[qname][1] = read
+        else:
+            if read.is_read1:
+                yield read, read_dict[qname][1]
+            else:
+                yield read_dict[qname][0], read
+            del read_dict[qname]
+
+
+def main(args):
+    """
+    """
+
+    # open the primer scheme and get the pools
+    bed = read_bed_file(args.bed)
+    
+    amplicon_checkpoints = get_initial_amplicon_checkpoints(bed)
+
+    for _ in range(args.amplicon_subdivisions - 1):
+        for amplicon_id in amplicon_checkpoints:
+            amplicon_checkpoints[amplicon_id] = subdivide_amplicon_checkpoints(amplicon_checkpoints[amplicon_id])
+    
+    genome_checkpoints = []
+    for checkpoints in amplicon_checkpoints.values():
+        genome_checkpoints.extend(checkpoints)
+    genome_checkpoints.sort()
+
+    required_depth_achieved = [False] * len(genome_checkpoints)
+    
+    depths = [0] * 30000
+
+    infile = pysam.AlignmentFile(args.bam, "rb")
+    bam_header = infile.header.copy().to_dict()
+
+    outfile = pysam.AlignmentFile("-", "wh", header=bam_header)
+
+    reads_processed = 0
+    reads_written = 0
+    reads_discarded = 0
+
+    for segment, mate_segment in read_pair_generator(infile):
+        if segment.mapping_quality < args.mapping_quality:
+            continue
+        if not segment.is_proper_pair:
+            continue
+        if segment.is_unmapped or segment.is_supplementary:
+            continue
+        if not segment.is_paired or segment.mate_is_unmapped:
+            continue
+
+        checkpoints_under_segment = list(filter(lambda cp: segment.reference_start <= cp and segment.reference_end >= cp, genome_checkpoints))
+        checkpoints_under_mate_segment = list(filter(lambda cp: mate_segment.reference_start <= cp and mate_segment.reference_end >= cp, genome_checkpoints))
+        checkpoints_under_both_segments = checkpoints_under_segment + checkpoints_under_mate_segment
+        checkpoint_depths = [depths[checkpoint] for checkpoint in checkpoints_under_both_segments]
+        checkpoints_achieved_required_depth = [True if depths[checkpoint] >= (args.depth * 0.5) else False for checkpoint in checkpoints_under_both_segments]
+        
+        if not all(checkpoints_achieved_required_depth):
+            outfile.write(segment)
+            reads_written += 1
+            outfile.write(mate_segment)
+            reads_written += 1
+            for checkpoint in checkpoints_under_both_segments:
+                depths[checkpoint] += 1
+        else:
+             reads_discarded += 2
+
+        reads_processed += 2
+
+        if reads_processed % 10000 == 0:
+            genome_checkpoint_depths = [depths[checkpoint] for checkpoint in genome_checkpoints]
+            genome_checkpoints_achieved_required_depth = [True if depth >= (args.depth * 0.5) else False for depth in genome_checkpoint_depths]
+            if all(genome_checkpoints_achieved_required_depth):
+                break
+
+    print("reads processed: " + str(reads_processed), file=sys.stderr)
+    print("reads written: " + str(reads_written), file=sys.stderr)
+    print("reads discarded: " + str(reads_discarded), file=sys.stderr)
+    # close up the file handles
+    infile.close()
+    outfile.close()
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Downsample alignments from an amplicon scheme.')
+    parser.add_argument('bam', help='bam file containing the alignment')
+    parser.add_argument('--bed', help='BED file containing the amplicon scheme')
+    parser.add_argument('--depth', type=int, default=200, help='Subsample to n coverage')
+    parser.add_argument('--mapping-quality', type=int, default=20, help='Minimum mapping quality to include read in output')
+    parser.add_argument('--amplicon-subdivisions', type=int, default=3, help='How many times to divide amplicons to detect coverage')
+    parser.add_argument('--verbose', action='store_true', help='Debug mode')
+    args = parser.parse_args()
+    main(args)

--- a/bin/downsample_amplicons.py
+++ b/bin/downsample_amplicons.py
@@ -282,7 +282,7 @@ def main(args):
             if all(genome_checkpoints_achieved_required_depth):
                 break
 
-    if reads_written > 0:
+    if total_reads > 0:
         downsampling_factor = reads_written / total_reads
     else:
         downsampling_factor = 0.0

--- a/bin/downsample_amplicons.py
+++ b/bin/downsample_amplicons.py
@@ -243,15 +243,19 @@ def main(args):
     for segment, mate_segment in read_pair_generator(infile):
         if segment.mapping_quality < args.mapping_quality:
             reads_discarded += 2
+            reads_processed += 2
             continue
         if not segment.is_proper_pair:
             reads_discarded += 2
+            reads_processed += 2
             continue
         if segment.is_unmapped or segment.is_supplementary:
             reads_discarded += 2
+            reads_processed += 2
             continue
         if not segment.is_paired or segment.mate_is_unmapped:
             reads_discarded += 2
+            reads_processed += 2
             continue
 
         checkpoints_under_segment = list(filter(lambda cp: segment.reference_start <= cp and segment.reference_end >= cp, genome_checkpoints))
@@ -278,8 +282,13 @@ def main(args):
             if all(genome_checkpoints_achieved_required_depth):
                 break
 
-    print('\t'.join(["total_input_reads","reads_processed","reads_written", "reads_discarded"]), file=sys.stderr)
-    print('\t'.join([str(total_reads), str(reads_processed), str(reads_written), str(reads_discarded)]), file=sys.stderr)
+    if reads_written > 0:
+        downsampling_factor = reads_written / total_reads
+    else:
+        downsampling_factor = 0.0
+
+    print(','.join(["total_input_reads","reads_processed","reads_written", "reads_discarded", "downsampling_factor"]), file=sys.stderr)
+    print(','.join([str(total_reads), str(reads_processed), str(reads_written), str(reads_discarded), str(round(downsampling_factor, 4))]), file=sys.stderr)
 
     # close up the file handles
     infile.close()

--- a/conf/illumina.config
+++ b/conf/illumina.config
@@ -34,13 +34,13 @@ params {
     illuminaQualThreshold = 20
 
     // Mpileup depth for ivar (although undocumented in mpileup, setting to zero removes limit)
-    mpileupDepth = 0
+    mpileupDepth = 100000
 
-    downsampleDepth = 500
+    downsampleMinDepth = 250
 
     downsampleMappingQuality = 20
 
-    downsampleAmpliconSubdivisions = 4
+    downsampleAmpliconSubdivisions = 3
     
     // iVar frequency threshold for consensus variant (ivar consensus: -t)
     ivarFreqThreshold = 0.75

--- a/conf/illumina.config
+++ b/conf/illumina.config
@@ -36,6 +36,12 @@ params {
     // Mpileup depth for ivar (although undocumented in mpileup, setting to zero removes limit)
     mpileupDepth = 0
 
+    downsampleDepth = 500
+
+    downsampleMappingQuality = 20
+
+    downsampleAmpliconSubdivisions = 4
+    
     // iVar frequency threshold for consensus variant (ivar consensus: -t)
     ivarFreqThreshold = 0.75
 

--- a/main.nf
+++ b/main.nf
@@ -4,7 +4,7 @@
 nextflow.preview.dsl = 2
 
 // include modules
-include printHelp from './modules/help.nf'
+include {printHelp} from './modules/help.nf'
 
 // import subworkflows
 include {articNcovNanopore} from './workflows/articNcovNanopore.nf' 

--- a/modules/qc.nf
+++ b/modules/qc.nf
@@ -28,6 +28,8 @@ process makeQCCSV {
 process writeQCSummaryCSV {
     tag { params.prefix }
 
+    executor 'local'
+
     input:
     val lines
 

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -6,9 +6,9 @@ process performHostFilter {
     publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${sampleId}_hostfiltered_R*.fastq.gz", mode: 'copy'
 
     input:
-        tuple(val(sampleId), path(forward), path(reverse))
+        tuple val(sampleId), path(forward), path(reverse)
     output:
-        tuple sampleId, path("${sampleId}_hostfiltered_R1.fastq.gz"), path("${sampleId}_hostfiltered_R2.fastq.gz"), emit: fastqPairs
+        tuple val(sampleId), path("${sampleId}_hostfiltered_R1.fastq.gz"), path("${sampleId}_hostfiltered_R2.fastq.gz"), emit: fastqPairs
 
     script:
         """
@@ -16,5 +16,25 @@ process performHostFilter {
             filter_non_human_reads.py -c ${params.viral_contig_name} > ${sampleId}.viral_and_nonmapping_reads.bam
         samtools sort -n ${sampleId}.viral_and_nonmapping_reads.bam | \
              samtools fastq -1 ${sampleId}_hostfiltered_R1.fastq.gz -2 ${sampleId}_hostfiltered_R2.fastq.gz -s ${sampleId}_singletons.fastq.gz -
+        """
+}
+
+process downsampleAmplicons {
+    cpus 2
+
+    tag { sampleId }
+
+    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${sampleId}.mapped.primertrimmed.downsampled.sorted{.bam,.bam.bai}", mode: 'copy'
+
+    input:
+        tuple val(sampleId), path(trimmed_bam), path(trimmed_bam_index), path(bedfile)
+    output:
+        tuple val(sampleId), path("${sampleId}.mapped.primertrimmed.downsampled.sorted.bam"), path("${sampleId}.mapped.primertrimmed.downsampled.sorted.bam.bai")
+
+    script:
+        """
+        downsample_amplicons.py --bed ${bedfile} --depth ${params.downsampleDepth) --mapping-quality ${params.downsampleMappingQuality} --amplicon-subdivisions ${params.downsampleAmpliconSubdivisions}  ${trimmed_bam} | \
+            samtools sort - -o ${sampleId}.primertrimmed.downsampled.sorted.bam
+        samtools index ${sampleId}.primertrimmed.downsampled.sorted.bam
         """
 }

--- a/modules/utils.nf
+++ b/modules/utils.nf
@@ -33,8 +33,8 @@ process downsampleAmplicons {
 
     script:
         """
-        downsample_amplicons.py --bed ${bedfile} --depth ${params.downsampleDepth) --mapping-quality ${params.downsampleMappingQuality} --amplicon-subdivisions ${params.downsampleAmpliconSubdivisions}  ${trimmed_bam} | \
-            samtools sort - -o ${sampleId}.primertrimmed.downsampled.sorted.bam
-        samtools index ${sampleId}.primertrimmed.downsampled.sorted.bam
+        downsample_amplicons.py --bed ${bedfile} --depth ${params.downsampleDepth} --mapping-quality ${params.downsampleMappingQuality} --amplicon-subdivisions ${params.downsampleAmpliconSubdivisions}  ${trimmed_bam} | \
+            samtools sort - -o ${sampleId}.mapped.primertrimmed.downsampled.sorted.bam
+        samtools index ${sampleId}.mapped.primertrimmed.downsampled.sorted.bam
         """
 }

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -16,6 +16,7 @@ include {cramToFastq} from '../modules/illumina.nf'
 include {alignConsensusToReference} from '../modules/illumina.nf'
 include {trimUTRFromAlignment} from '../modules/illumina.nf'
 include {performHostFilter} from '../modules/utils'
+include {downsampleAmplicons} from '../modules/utils'
 
 include {makeQCCSV} from '../modules/qc.nf'
 include {writeQCSummaryCSV} from '../modules/qc.nf'
@@ -98,7 +99,9 @@ workflow sequenceAnalysis {
 
       trimPrimerSequences(readMapping.out.combine(ch_bedFile))
 
-      callVariants(trimPrimerSequences.out.ptrim.combine(ch_preparedRef.map{ it[0] }))     
+      downsampleAmplicons(trimPrimerSequences.out.ptrim.combine(ch_bedFile))
+
+      callVariants(downsampleAmplicons.out.combine(ch_preparedRef.map{ it[0] }))     
 
       makeConsensus(trimPrimerSequences.out.ptrim)
 
@@ -106,7 +109,7 @@ workflow sequenceAnalysis {
 
       trimUTRFromAlignment(alignConsensusToReference.out)
 
-      makeQCCSV(trimPrimerSequences.out.ptrim.join(makeConsensus.out, by: 0)
+      makeQCCSV(downsampleAmplicons.out.join(makeConsensus.out, by: 0)
                                    .combine(ch_preparedRef.map{ it[0] }))
 
       makeQCCSV.out.csv.splitCsv()


### PR DESCRIPTION
Add workflow steps to down-sample reads from alignments. Downsampling strategy is designed to preserve reads in low-coverage areas while discarding excess reads from high-coverage areas.

A summary describing how many reads were kept (written) and discarded is also produced.

After downsampling, reads from downsampled alignments are converted to .fastq.gz format for upload to NML.

Variant calling and consensus file generation is done based on downsampled amplicons.